### PR TITLE
Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,17 @@ language: scala
 scala:
   - 2.10.4
   - 2.11.8
+  - 2.12.1
 jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6
+matrix:
+ exclude:
+  - scala: 2.12.1
+    jdk: openjdk6
+  - scala: 2.12.1
+    jdk: openjdk7
+  - scala: 2.12.1
+    jdk: oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,17 @@ language: scala
 scala:
   - 2.10.4
   - 2.11.8
+  - 2.12.0
 jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6
+matrix:
+  exclude:
+  - scala: 2.12.0
+    jdk: openjdk6
+  - scala: 2.12.0
+    jdk: openjdk7
+  - scala: 2.12.0
+    jdk: oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ scala:
   - 2.11.8
   - 2.12.1
 jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
   - openjdk6
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
 matrix:
  exclude:
   - scala: 2.12.1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of a sealed class.
 
 ## Set Up
 
-Sealerate is available for both Scala 2.10 and 2.11. If you are using sbt, add
+Sealerate is available for Scala 2.10, 2.11 and 2.12. If you are using sbt, add
 the following to your `build.sbt`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sealerate is available for Scala 2.10, 2.11 and 2.12. If you are using sbt, add
 the following to your `build.sbt`:
 
 ```
-libraryDependencies += "ca.mrvisser" %% "sealerate" % "0.0.4"
+libraryDependencies += "ca.mrvisser" %% "sealerate" % "0.0.5"
 ```
 
 ## Example Usage

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,9 @@ pomExtra := {
   </developers>
 }
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
 
-crossScalaVersions := Seq("2.10.4", "2.11.8")
+crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.1")
 
 scalacOptions ++= Seq(
   "-Xlint",

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-compiler" % _)
+libraryDependencies += scalaVersion("org.scala-lang" % "scala-compiler" % _).value
 
 libraryDependencies ++= Seq(
   Dependencies.Test.scalaTest

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,9 @@ pomExtra := {
   </developers>
 }
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
-crossScalaVersions := Seq("2.10.4", "2.11.8")
+crossScalaVersions := Seq("2.10.4", "2.11.8", "2.12.0")
 
 scalacOptions ++= Seq(
   "-Xlint",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Version {
     val macros = "2.1.0"
-    val scalaTest = "3.0.0"
+    val scalaTest = "3.0.1"
     val typesafeConfig  = "1.2.1"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Version {
     val macros = "2.1.0"
-    val scalaTest = "3.0.0"
+    val scalaTest = "3.0.1"
     val typesafeConfig  = "1.3.1"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
 
   object Version {
-    val macros = "2.0.1"
-    val scalaTest = "2.2.1"
+    val macros = "2.1.0"
+    val scalaTest = "3.0.1"
     val typesafeConfig  = "1.2.1"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
 
   object Version {
-    val macros = "2.0.1"
-    val scalaTest = "2.2.1"
-    val typesafeConfig  = "1.2.1"
+    val macros = "2.1.0"
+    val scalaTest = "3.0.0"
+    val typesafeConfig  = "1.3.1"
   }
 
   object Compiler {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Version {
     val macros = "2.1.0"
     val scalaTest = "3.0.1"
-    val typesafeConfig  = "1.3.1"
+    val typesafeConfig  = "1.2.1"
   }
 
   object Compiler {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Version {
     val macros = "2.1.0"
     val scalaTest = "3.0.1"
-    val typesafeConfig  = "1.2.1"
+    val typesafeConfig  = "1.3.1"
   }
 
   object Compiler {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   object Version {
     val macros = "2.1.0"
-    val scalaTest = "3.0.1"
+    val scalaTest = "3.0.0"
     val typesafeConfig  = "1.2.1"
   }
 

--- a/src/main/scala_2.12/ca/mrvisser/sealerate/macrocompat/package.scala
+++ b/src/main/scala_2.12/ca/mrvisser/sealerate/macrocompat/package.scala
@@ -1,0 +1,8 @@
+package ca.mrvisser.sealerate
+
+package object macrocompat {
+  type Context = scala.reflect.macros.blackbox.Context
+
+  def termName(c: Context)(name: String): c.universe.TermName =
+    c.universe.TermName(name)
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.0.4"
+version := "0.0.5-SNAPSHOT"


### PR DESCRIPTION
Here is a PR for scala 2.12 support. I don't know anything about travis, but still attempted to update the .travis.yml file after a quick look at the docs - hope it's right.

The libs for macros and scalatest needed to be updated for 2.12 support and I went ahead and bumped typesafe config too.