### PR TITLE
Update scalatest to 3.2.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Version {
-    val scalaTest = "3.0.8"
+    val scalaTest = "3.2.5"
   }
 
   object Test {

--- a/src/test/scala/ca/mrvisser/sealerate/SealerateSpec.scala
+++ b/src/test/scala/ca/mrvisser/sealerate/SealerateSpec.scala
@@ -1,8 +1,9 @@
 package ca.mrvisser.sealerate
 
-import org.scalatest.{Matchers, path}
+import org.scalatest.funspec.PathAnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SealerateSpec extends path.FunSpec with Matchers {
+class SealerateSpec extends PathAnyFunSpec with Matchers {
 
   describe("values") {
     it("should give a list of values for sealed classes") {


### PR DESCRIPTION
This version also supports Scala 3.0.0-RC1. So it will be easier to work on Scala 3.

